### PR TITLE
[Config] Fix lachesis config element

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	Log Log `mapstructure:"log"`
 
 	// Lachesis represents the node structure
-	Lachesis Lachesis `mapstructure:"node"`
+	Lachesis Lachesis `mapstructure:"lachesis"`
 
 	// Database configuration
 	Db Database `mapstructure:"db"`


### PR DESCRIPTION
lachesis url is not marshalled from viper into config.
This leads to the fact that api cannot access lachesis node (empty URL in config).

This PR fixes the mapstructure so it matches the key.