### PR TITLE
add last contract to list

### DIFF
--- a/internal/repository/db/contract.go
+++ b/internal/repository/db/contract.go
@@ -568,12 +568,12 @@ func (db *MongoDbBridge) contractListLoad(col *mongo.Collection, validatedOnly b
 	}
 
 	// we should have all the items already; we may just need to check if a boundary was reached
-	if cursor != nil {
+	if contract != nil {
 		list.IsEnd = count > 0 && int32(len(list.Collection)) < count
 		list.IsStart = count < 0 && int32(len(list.Collection)) < -count
 
 		// add the last item as well
-		if (list.IsStart || list.IsEnd) && contract != nil {
+		if (list.IsStart || list.IsEnd) {
 			list.Collection = append(list.Collection, contract)
 			list.Last = contract.OrdinalIndex
 		}


### PR DESCRIPTION
Using Fantom-PWA-explorer does not show the last contract created.

Reproduction:
- Setup lachesis fakenet
- deploy one contract
- retrieve the list of contracts via graphql in fantom-api-graphql
Note: PWA exporer requests the first list chunk with cursor=null.

The query result contains the correct number of contracts (1), but no contract is returned.